### PR TITLE
fix: broken link for shrewnit

### DIFF
--- a/src/content/blog/spring-update-25.md
+++ b/src/content/blog/spring-update-25.md
@@ -224,7 +224,7 @@ cargo add autons
 
 ## `shrewnit`
 
-[`shrewnit`]((https://crates.io/crates/shrewnit)) is a new units library that allows you to strongly type units of measure at compile time in stable rust. This library isn't specific to vexide, but is developed by one of our maintainers with vexide and its projects in mind.
+[`shrewnit`](https://crates.io/crates/shrewnit) is a new units library that allows you to strongly type units of measure at compile time in stable rust. This library isn't specific to vexide, but is developed by one of our maintainers with vexide and its projects in mind.
 
 ## `doxa-selector`
 


### PR DESCRIPTION
The extra parentheses cause the link to be treated as a relative path, causing it to navigate to `https://vexide.dev/blog/posts/spring-update-25/(https://crates.io/crates/shrewnit)` rather than the intended target.