### PR TITLE
Update API Reference link for Inertial Sensor

### DIFF
--- a/src/content/docs/controller.md
+++ b/src/content/docs/controller.md
@@ -1,7 +1,7 @@
 ---
 title: Controller
 links: {
-    "API Reference": "https://docs.rs/vexide/latest/vexide/devices/controller/struct.Controller.html",
+    "API Reference": "https://docs.rs/vexide/latest/vexide/controller/index.html",
     "SIGBots Wiki": "https://wiki.purduesigbots.com/vex-electronics/vex-electronics/vex-joystick",
     "VEX Library":  "https://kb.vex.com/hc/en-us/articles/360035589632-V5-Controller-Overview",
 }

--- a/src/content/docs/distance-sensor.md
+++ b/src/content/docs/distance-sensor.md
@@ -1,7 +1,7 @@
 ---
 title: Distance Sensor
 links: {
-    "API Reference": "https://docs.rs/vexide/latest/vexide/devices/smart/distance/struct.DistanceSensor.html",
+    "API Reference": "https://docs.rs/vexide/latest/vexide/smart/distance/index.html",
     "SIGBots Wiki": "https://wiki.purduesigbots.com/vex-electronics/vex-sensors/smart-port-sensors/distance",
     "VEX Library":  "https://kb.vex.com/hc/en-us/articles/360050696511-Using-the-Distance-Sensor-with-VEX-V5",
 }

--- a/src/content/docs/inertial-sensor.md
+++ b/src/content/docs/inertial-sensor.md
@@ -1,7 +1,7 @@
 ---
 title: Inertial Sensor
 links: {
-    "API Reference": "https://docs.rs/vexide/latest/vexide/devices/smart/imu/struct.InertialSensor.html",
+    "API Reference": "https://docs.rs/vexide/latest/vexide/smart/imu/index.html",
     "SIGBots Wiki": "https://wiki.purduesigbots.com/vex-electronics/vex-sensors/smart-port-sensors/imu",
     "VEX Library":  "https://kb.vex.com/hc/en-us/articles/360037382272-Using-the-Inertial-Sensor-with-VEX-V5",
 }

--- a/src/content/docs/motor.md
+++ b/src/content/docs/motor.md
@@ -1,7 +1,7 @@
 ---
 title: Motor
 links: {
-    "API Reference": "https://docs.rs/vexide/latest/vexide/devices/smart/motor/struct.Motor.html",
+    "API Reference": "https://docs.rs/vexide/latest/vexide/smart/motor/index.html",
     "SIGBots Wiki": "https://wiki.purduesigbots.com/vex-electronics/vex-electronics/motors",
     "VEX Library":  "https://kb.vex.com/hc/en-us/articles/360035591332-V5-Motor-Overview",
 }

--- a/src/content/docs/peripherals.mdx
+++ b/src/content/docs/peripherals.mdx
@@ -1,7 +1,7 @@
 ---
 title: Peripherals
 links: {
-    "API Reference": "https://docs.rs/vexide/latest/vexide/devices/peripherals/struct.Peripherals.html",
+    "API Reference": "https://docs.rs/vexide/latest/vexide/peripherals/index.html",
 }
 ---
 


### PR DESCRIPTION
I noticed that all of the API Reference links on the webpage where wrong and redirected me to pages that no longer exist